### PR TITLE
Fixed String constructor call in GetCoverageStep

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinecoverageresults/GetCoverageStep.java
+++ b/src/main/java/io/jenkins/plugins/pipelinecoverageresults/GetCoverageStep.java
@@ -54,7 +54,7 @@ public class GetCoverageStep extends Step {
         if (element != null) {
             this.element = element;
         } else {
-            this.element = new String("Line");
+            this.element = "Line";
         }
     }
 


### PR DESCRIPTION
When trying to build the project using Maven, the spotbugs plugin caused an error for the line changed with this warning:

```
[ERROR] new io.jenkins.plugins.pipelinecoverageresults.GetCoverageStep(String) invokes inefficient new String(String) constructor [io.jenkins.plugins.pipelinecoverageresults.GetCoverageStep] At GetCoverageStep.java:[line 57] DM_STRING_CTOR
```

As such, I changed the line of code in question, and the HPI built.